### PR TITLE
Disable tag editing without login in UI

### DIFF
--- a/lib/philomena_web/templates/image/_tags.html.slime
+++ b/lib/philomena_web/templates/image/_tags.html.slime
@@ -2,7 +2,7 @@
 
 .js-tagsauce#image_tags_and_source
   .js-imageform class=form_class
-    = if can?(@conn, :edit_metadata, @image) and !@conn.assigns.current_ban do
+    = if can?(@conn, :edit_metadata, @image) and !@conn.assigns.current_ban and @conn.assigns.current_user do
 
       = form_for @changeset, Routes.image_tag_path(@conn, :update, @image), [id: "tags-form", method: "put", data: [remote: true]], fn f ->
         = if @changeset.action do
@@ -48,7 +48,7 @@
 
     - else
       p
-        ' You can't edit the tags on this image.
+        ' You can't edit the tags on this image. Either you are not logged in or tag editing has been disabled for this image.
 
   .tagsauce
     .block


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

- require user to be logged in for tag editing in UI. Contains a captcha, so no need to edit backend components.