### PR TITLE
disable source editing without login in UI

### DIFF
--- a/lib/philomena_web/templates/image/_source.html.slime
+++ b/lib/philomena_web/templates/image/_source.html.slime
@@ -1,6 +1,6 @@
 .block
   = form_for @changeset, Routes.image_source_path(@conn, :update, @image), [method: "put", class: "hidden", id: "source-form", data: [remote: true]], fn f ->
-    = if can?(@conn, :edit_metadata, @image) and !@conn.assigns.current_ban do
+    = if can?(@conn, :edit_metadata, @image) and !@conn.assigns.current_ban and @conn.assigns.current_user do
 
       = if @changeset.action do
         .alert.alert-danger
@@ -18,7 +18,7 @@
 
     - else
       p
-        ' You can't edit the source on this image.
+        ' You can't edit the source on this image. Either you are not logged in or source editing has been disabled for this image.
 
   .flex.flex--wrap#image-source
     p


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

- disabled source editing without login in UI. Has captcha, thus no need to change backend.
