### PR TITLE
Place limitations on names.

### DIFF
--- a/lib/philomena/notable.ex
+++ b/lib/philomena/notable.ex
@@ -1,0 +1,33 @@
+defmodule Philomena.Notable do
+
+  import Ecto.Query, warn: false
+
+  alias Philomena.Repo
+  alias Philomena.Notable.Name
+
+  @doc """
+  List all notable names.
+  """
+  def list_names do
+    Repo.all(Name)
+  end
+
+  @doc """
+  Checks username against table of notable names.
+  """
+  def notable_name?(name) do
+    if have_table() do
+      name = name |> String.downcase
+		  Repo.exists?(from n in Name,
+        where: fragment("lower(?)", n.name) == ^name)
+    else
+      false
+    end
+  end
+
+  defp have_table() do
+    alias Ecto.Adapters.SQL
+
+    SQL.table_exists?(Repo, "notable_names")
+  end
+end

--- a/lib/philomena_web/controllers/registration/name_controller.ex
+++ b/lib/philomena_web/controllers/registration/name_controller.ex
@@ -5,6 +5,8 @@ defmodule PhilomenaWeb.Registration.NameController do
 
   plug PhilomenaWeb.FilterBannedUsersPlug
   plug :verify_authorized
+  plug PhilomenaWeb.NameLengthLimiterPlug when action in [:update]
+  plug PhilomenaWeb.NotableNamePlug when action in [:update]
 
   def edit(conn, _params) do
     changeset = Users.change_user(conn.assigns.current_user)

--- a/lib/philomena_web/controllers/registration/new_controller.ex
+++ b/lib/philomena_web/controllers/registration/new_controller.ex
@@ -1,0 +1,59 @@
+defmodule PhilomenaWeb.Registration.NewController do
+  use PhilomenaWeb, :controller
+
+  alias Plug.Conn
+
+  plug :verify_captcha
+  plug PhilomenaWeb.NameLengthLimiterPlug
+  plug PhilomenaWeb.NotableNamePlug
+
+  @doc """
+  Create new user, if everything seems to be in order.
+  """
+  @spec create(Conn.t(), map()) :: Conn.t()
+  def create(conn, %{"user" => user_params}) do
+    alias Pow.Plug
+
+    conn
+      |> Plug.create_user(user_params)
+      |> yea_neigh()
+  end
+
+  @doc """
+  Greet new user, or return to registration page on fail.
+  """
+  @spec yea_neigh({:ok | :error, map(), Conn.t()}) :: Conn.t()
+  defp yea_neigh({:ok, _user, conn}) do
+    conn
+    |> put_flash(:info, "Mellow greetings, citizen!")
+    |> redirect(to: "/")
+  end
+  defp yea_neigh({:error, changeset, conn}) do
+    conn
+    |> assign(:changeset, changeset)
+    |> render("new.html")
+  end
+
+  @doc """
+  Verify captcha.
+  """
+  defp verify_captcha(conn, _opts) do
+    alias Pow.Plug
+    alias Pow.Config
+    alias Phoenix.Controller
+
+    config   = Plug.fetch_config(conn)
+    verifier = Config.get(config, :captcha_verifier)
+
+    case verifier.valid_solution?(conn.params) do
+      false ->
+        conn
+          |> Controller.put_flash(:error,
+            "There was an error verifying you're not a robot. Please try again.")
+          |> Controller.redirect(external: conn.assigns.referrer)
+          |> Conn.halt()
+      true ->
+        conn
+    end
+  end
+end

--- a/lib/philomena_web/plugs/name_length_limiter_plug.ex
+++ b/lib/philomena_web/plugs/name_length_limiter_plug.ex
@@ -1,0 +1,32 @@
+defmodule PhilomenaWeb.NameLengthLimiterPlug do
+	alias Phoenix.Controller
+	alias Plug.Conn
+
+	def init([]), do: []
+
+	def call(conn), do: call(conn, nil)
+
+	def call(conn, _opts) do
+    name = conn.params["user"]["name"]
+
+	  conn
+	  |> check_length(name)
+  end
+
+  defp check_length(conn, name) do
+    if too_long?(name) do
+      conn
+      |> Controller.fetch_flash()
+      |> Controller.put_flash(:error, "Names must be 80 characters or shorter.")
+      |> Controller.redirect(external: conn.assigns.referrer)
+      |> Conn.halt()
+    else
+      conn
+    end
+  end
+
+	defp too_long?(name) do
+		String.length(name) > 80
+	end
+
+end

--- a/lib/philomena_web/plugs/notable_name_plug.ex
+++ b/lib/philomena_web/plugs/notable_name_plug.ex
@@ -1,0 +1,44 @@
+defmodule PhilomenaWeb.NotableNamePlug do
+	alias Philomena.Notable
+	alias Phoenix.Controller
+	alias Plug.Conn
+
+	def init([]), do: []
+
+	def call(conn), do: call(conn, nil)
+
+	def call(conn, _opts) do
+    name = conn.params["user"]["name"]
+
+	  conn
+	  |> check_notable(name)
+  end
+
+  defp mod?(%{role: role}) when role in ["moderator", "admin"], do: true
+  defp mod?(_user), do: false
+
+  defp check_notable(conn, user_name) do
+	  if Notable.notable_name?(user_name) do
+	    conn
+	    |> allow_mods
+	  else
+	    conn
+    end
+  end
+
+  defp allow_mods(conn) do
+    unless mod?(conn.assigns.current_user) do
+      import Phoenix.HTML.Link, only: [link: 2]
+
+      conn
+        |> Controller.fetch_flash()
+        |> Controller.put_flash(:error, ["That username is reserved for a notable fandom artist. Please choose another, and if you are the artist in question, ", link("contact the moderators", to: "/forums/meta"), " for verification."])
+        |> Controller.redirect(external: conn.assigns.referrer)
+        |> Conn.halt()
+    else
+      conn
+    end
+  end
+
+
+end

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -70,6 +70,8 @@ defmodule PhilomenaWeb.Router do
       :ensure_password_not_compromised
     ]
 
+    resources "/registration", PhilomenaWeb.Registration.NewController, only: [:create], singleton: true
+
     pow_registration_routes()
   end
 

--- a/lib/pow_captcha/phoenix/controllers/controller_callbacks.ex
+++ b/lib/pow_captcha/phoenix/controllers/controller_callbacks.ex
@@ -8,19 +8,10 @@ defmodule PowCaptcha.Phoenix.ControllerCallbacks do
   alias Plug.Conn
   alias Phoenix.Controller
 
-  alias Pow.Phoenix.RegistrationController
   alias PowResetPassword.Phoenix.ResetPasswordController
 
   @doc false
   @impl true
-  def before_process(RegistrationController, :create, conn, config) do
-    verifier = Config.get(config, :captcha_verifier)
-    return_path = routes(conn).registration_path(conn, :new)
-
-    verifier.valid_solution?(conn.params)
-    |> maybe_halt(conn, return_path)
-  end
-
   def before_process(ResetPasswordController, :create, conn, config) do
     verifier = Config.get(config, :captcha_verifier)
     return_path = routes(conn).path_for(conn, ResetPasswordController, :new)


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Adds two new plugs, NotableNamePlug with associated DB table schema, which will block registration or changing to any name in the notable_names table, if it exists, and NameLengthLimiterPlug, which...limits the lengths of names (to 80 characters max).  Adds Registration.NewController to handle new user registration, passing through the new plugs.  Modifies NameController to use new plugs.  Modifies Router to use new controller, and controller callbacks to remove old captcha-verification registration callback.