### PR TITLE
Name limits

### DIFF
--- a/assets/css/common/_base.scss
+++ b/assets/css/common/_base.scss
@@ -86,6 +86,10 @@ a:hover {
   color: $link_hover_color;
 }
 
+p a {
+  font-weight: bold;
+}
+
 img {
   margin: 0;
   border: 0;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -3204,9 +3204,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",

--- a/create_notable_table.sql
+++ b/create_notable_table.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS notable_names (
+	name		varchar PRIMARY KEY,
+	source	text NOT NULL,
+
+	created_at timestamp DEFAULT current_timestamp
+);
+
+DROP TRIGGER IF EXISTS notable_name_insert_trigger on public.notable_names;
+
+CREATE OR REPLACE FUNCTION notable_name_processing(name text)
+RETURNS text AS '
+BEGIN
+	name := regexp_replace(name,''[|/\.,?><:~!@#$%^&*_=+\011\042\047\050\051\073\133\135\140\173\175-]+'','''',''g'');
+	name := regexp_replace(name,''\s+'','''',''g'');
+	name := LOWER(name);
+	RETURN name;
+END' LANGUAGE 'plpgsql';	
+
+CREATE OR REPLACE FUNCTION notable_name_query(query_name text)
+RETURNS TABLE (name varchar, source text, created_at timestamp) AS '
+BEGIN
+	query_name := notable_name_processing(query_name);
+	RETURN QUERY SELECT * FROM notable_names WHERE notable_names.name=query_name;
+END' LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION notable_name_insert_processing()
+RETURNS trigger AS '
+BEGIN
+	NEW.name := notable_name_processing(NEW.name);
+	RETURN NEW;
+END' LANGUAGE 'plpgsql';
+
+CREATE TRIGGER notable_name_insert_trigger
+BEFORE INSERT ON notable_names
+FOR EACH ROW
+EXECUTE PROCEDURE notable_name_insert_processing();

--- a/insert_notable_tests.sql
+++ b/insert_notable_tests.sql
@@ -1,0 +1,6 @@
+INSERT INTO notable_names (name, source) values
+	('Bob Dole', 'derpi artist: tags'),
+	('JimBeam', 'derpi DNP'),
+	('fred_Penner', 'derpi artist: tags'),
+	('_-^no~u^-_', 'derpi DNP'),
+	('徐詩珮', 'derpi artist: tags');

--- a/lib/philomena/notable.ex
+++ b/lib/philomena/notable.ex
@@ -1,0 +1,33 @@
+defmodule Philomena.Notable do
+
+  import Ecto.Query, warn: false
+
+  alias Philomena.Repo
+  alias Philomena.Notable.Name
+
+  @doc """
+  List all notable names.
+  """
+  def list_names do
+    Repo.all(Name)
+  end
+
+  @doc """
+  Checks username against table of notable names.
+  """
+  def notable_name?(name) do
+    if have_table() do
+      name = name |> String.downcase
+		  Repo.exists?(from n in Name,
+        where: fragment("lower(?)", n.name) == ^name)
+    else
+      false
+    end
+  end
+
+  defp have_table() do
+    alias Ecto.Adapters.SQL
+
+    SQL.table_exists?(Repo, "notable_names")
+  end
+end

--- a/lib/philomena/notable.ex
+++ b/lib/philomena/notable.ex
@@ -1,6 +1,7 @@
 defmodule Philomena.Notable do
 
   import Ecto.Query, warn: false
+  alias Ecto.Adapters.SQL
 
   alias Philomena.Repo
   alias Philomena.Notable.Name
@@ -17,17 +18,22 @@ defmodule Philomena.Notable do
   """
   def notable_name?(name) do
     if have_table() do
-      name = name |> String.downcase
-		  Repo.exists?(from n in Name,
-        where: fragment("notable_name_query(?)", n.name))
+      case nnquery(name) do
+        {:ok, res} ->
+          res.num_rows > 0
+        {:error, err} ->
+          false
+      end
     else
       false
     end
   end
 
-  defp have_table() do
-    alias Ecto.Adapters.SQL
+  defp nnquery(name) do
+    SQL.query(Repo, "SELECT * FROM notable_name_query($1)", [name])
+  end
 
+  defp have_table() do
     SQL.table_exists?(Repo, "notable_names")
   end
 end

--- a/lib/philomena/notable.ex
+++ b/lib/philomena/notable.ex
@@ -19,7 +19,7 @@ defmodule Philomena.Notable do
     if have_table() do
       name = name |> String.downcase
 		  Repo.exists?(from n in Name,
-        where: fragment("lower(?)", n.name) == ^name)
+        where: fragment("notable_name_query(?)", n.name))
     else
       false
     end

--- a/lib/philomena/notable/name.ex
+++ b/lib/philomena/notable/name.ex
@@ -1,0 +1,18 @@
+defmodule Philomena.Notable.Name do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "notable_names" do
+    field :name, :string
+    field :source, :string
+
+    timestamps(inserted_at: :created_at)
+  end
+
+  @doc false
+  def changeset(name, attrs) do
+    name
+    |> cast(attrs, [])
+    |> validate_required([])
+  end
+end

--- a/lib/philomena_web/controllers/registration/name_controller.ex
+++ b/lib/philomena_web/controllers/registration/name_controller.ex
@@ -5,6 +5,8 @@ defmodule PhilomenaWeb.Registration.NameController do
 
   plug PhilomenaWeb.FilterBannedUsersPlug
   plug :verify_authorized
+  plug PhilomenaWeb.NameLengthLimiterPlug when action in [:update]
+  plug PhilomenaWeb.NotableNamePlug when action in [:update]
 
   def edit(conn, _params) do
     changeset = Users.change_user(conn.assigns.current_user)

--- a/lib/philomena_web/controllers/registration/new_controller.ex
+++ b/lib/philomena_web/controllers/registration/new_controller.ex
@@ -1,0 +1,59 @@
+defmodule PhilomenaWeb.Registration.NewController do
+  use PhilomenaWeb, :controller
+
+  alias Plug.Conn
+
+  plug :verify_captcha
+  plug PhilomenaWeb.NameLengthLimiterPlug
+  plug PhilomenaWeb.NotableNamePlug
+
+  @doc """
+  Create new user, if everything seems to be in order.
+  """
+  @spec create(Conn.t(), map()) :: Conn.t()
+  def create(conn, %{"user" => user_params}) do
+    alias Pow.Plug
+
+    conn
+      |> Plug.create_user(user_params)
+      |> yea_neigh()
+  end
+
+  @doc """
+  Greet new user, or return to registration page on fail.
+  """
+  @spec yea_neigh({:ok | :error, map(), Conn.t()}) :: Conn.t()
+  defp yea_neigh({:ok, _user, conn}) do
+    conn
+    |> put_flash(:info, "Mellow greetings, citizen!")
+    |> redirect(to: "/")
+  end
+  defp yea_neigh({:error, changeset, conn}) do
+    conn
+    |> assign(:changeset, changeset)
+    |> render("new.html")
+  end
+
+  @doc """
+  Verify captcha.
+  """
+  defp verify_captcha(conn, _opts) do
+    alias Pow.Plug
+    alias Pow.Config
+    alias Phoenix.Controller
+
+    config   = Plug.fetch_config(conn)
+    verifier = Config.get(config, :captcha_verifier)
+
+    case verifier.valid_solution?(conn.params) do
+      false ->
+        conn
+          |> Controller.put_flash(:error,
+            "There was an error verifying you're not a robot. Please try again.")
+          |> Controller.redirect(external: conn.assigns.referrer)
+          |> Conn.halt()
+      true ->
+        conn
+    end
+  end
+end

--- a/lib/philomena_web/plugs/name_length_limiter_plug.ex
+++ b/lib/philomena_web/plugs/name_length_limiter_plug.ex
@@ -1,0 +1,32 @@
+defmodule PhilomenaWeb.NameLengthLimiterPlug do
+	alias Phoenix.Controller
+	alias Plug.Conn
+
+	def init([]), do: []
+
+	def call(conn), do: call(conn, nil)
+
+	def call(conn, _opts) do
+    name = conn.params["user"]["name"]
+
+	  conn
+	  |> check_length(name)
+  end
+
+  defp check_length(conn, name) do
+    if too_long?(name) do
+      conn
+      |> Controller.fetch_flash()
+      |> Controller.put_flash(:error, "Names must be 80 characters or shorter.")
+      |> Controller.redirect(external: conn.assigns.referrer)
+      |> Conn.halt()
+    else
+      conn
+    end
+  end
+
+	defp too_long?(name) do
+		String.length(name) > 80
+	end
+
+end

--- a/lib/philomena_web/plugs/notable_name_plug.ex
+++ b/lib/philomena_web/plugs/notable_name_plug.ex
@@ -1,0 +1,44 @@
+defmodule PhilomenaWeb.NotableNamePlug do
+	alias Philomena.Notable
+	alias Phoenix.Controller
+	alias Plug.Conn
+
+	def init([]), do: []
+
+	def call(conn), do: call(conn, nil)
+
+	def call(conn, _opts) do
+    name = conn.params["user"]["name"]
+
+	  conn
+	  |> check_notable(name)
+  end
+
+  defp mod?(%{role: role}) when role in ["moderator", "admin"], do: true
+  defp mod?(_user), do: false
+
+  defp check_notable(conn, user_name) do
+	  if Notable.notable_name?(user_name) do
+	    conn
+	    |> allow_mods
+	  else
+	    conn
+    end
+  end
+
+  defp allow_mods(conn) do
+    unless mod?(conn.assigns.current_user) do
+      import Phoenix.HTML.Link, only: [link: 2]
+
+      conn
+        |> Controller.fetch_flash()
+        |> Controller.put_flash(:error, ["That username is reserved for a notable fandom artist. Please choose another, and if you are the artist in question, ", link("contact the moderators", to: "/forums/meta"), " for verification."])
+        |> Controller.redirect(external: conn.assigns.referrer)
+        |> Conn.halt()
+    else
+      conn
+    end
+  end
+
+
+end

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -70,6 +70,8 @@ defmodule PhilomenaWeb.Router do
       :ensure_password_not_compromised
     ]
 
+    resources "/registration", PhilomenaWeb.Registration.NewController, only: [:create], singleton: true
+
     pow_registration_routes()
   end
 

--- a/lib/pow_captcha/phoenix/controllers/controller_callbacks.ex
+++ b/lib/pow_captcha/phoenix/controllers/controller_callbacks.ex
@@ -8,19 +8,10 @@ defmodule PowCaptcha.Phoenix.ControllerCallbacks do
   alias Plug.Conn
   alias Phoenix.Controller
 
-  alias Pow.Phoenix.RegistrationController
   alias PowResetPassword.Phoenix.ResetPasswordController
 
   @doc false
   @impl true
-  def before_process(RegistrationController, :create, conn, config) do
-    verifier = Config.get(config, :captcha_verifier)
-    return_path = routes(conn).registration_path(conn, :new)
-
-    verifier.valid_solution?(conn.params)
-    |> maybe_halt(conn, return_path)
-  end
-
   def before_process(ResetPasswordController, :create, conn, config) do
     verifier = Config.get(config, :captcha_verifier)
     return_path = routes(conn).path_for(conn, ResetPasswordController, :new)


### PR DESCRIPTION
- Adds two new Plugs:
  -  NotableNamePlug with associated backing functions and DB table schema, which will block registration or changing to any name in the notable_names table, if it exists.  Code relies on the presence of postgresql helper functions and a trigger that process names both on insert and query, removing punctuation and spaces, and downcasing.  Scripts added to root dir that create the notable_names table and its associated functions and insert trigger, and insert a small set of test names.  Admins and moderators with user management permissions are able to change user's names to restricted names.
  - NameLengthLimiterPlug, which...limits the lengths of names (to 80 characters max).
- Adds Registration.NewController to handle new user registration, passing through the new plugs.
- Modifies Router to use NewController on user creation.
- Modifies controller callbacks to remove old captcha-verification registration callback.
- Modifies NameController to use new plugs on user name change.