### PR TITLE
Disable creating new Conversations (private-message threads) for normal users.

### DIFF
--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -59,6 +59,12 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   # View conversations
   def can?(%User{role: "moderator"}, :show, %Conversation{}), do: true
 
+  # Create new conversations
+  def can?(%User{role: "moderator"}, :new, %Conversation{}), do: true
+  def can?(%User{role: "moderator"}, :create, %Conversation{}), do: true
+  def can?(%User{role: "moderator"}, :new, Conversation), do: true
+  def can?(%User{role: "moderator"}, :create, Conversation), do: true
+
   # View IP addresses and fingerprints
   def can?(%User{role: "moderator"}, :show, :ip_address), do: true
 

--- a/lib/philomena_web/controllers/conversation_controller.ex
+++ b/lib/philomena_web/controllers/conversation_controller.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.ConversationController do
   import Ecto.Query
 
   plug PhilomenaWeb.FilterBannedUsersPlug when action in [:new, :create]
+  plug :verify_authorized when action in [:new, :create]
 
   plug :load_and_authorize_resource,
     model: Conversation,
@@ -109,6 +110,13 @@ defmodule PhilomenaWeb.ConversationController do
       {:error, changeset} ->
         conn
         |> render("new.html", changeset: changeset)
+    end
+  end
+
+  defp verify_authorized(conn, _opts) do
+    case Canada.Can.can?(conn.assigns.current_user, action_name(conn), Conversation) do
+      true -> conn
+      _false -> PhilomenaWeb.NotAuthorizedPlug.call(conn)
     end
   end
 end

--- a/lib/philomena_web/templates/conversation/index.html.slime
+++ b/lib/philomena_web/templates/conversation/index.html.slime
@@ -5,9 +5,10 @@ elixir:
 h1 My Conversations
 .block
   .block__header
-    a href=Routes.conversation_path(@conn, :new)
-      i.fa.fa-paper-plane>
-      ' Create New Conversation
+    = if can_create_convo?(@conn) do
+      a href=Routes.conversation_path(@conn, :new)
+        i.fa.fa-paper-plane>
+        ' Create New Conversation
 
     = pagination
 

--- a/lib/philomena_web/templates/profile/show.html.slime
+++ b/lib/philomena_web/templates/profile/show.html.slime
@@ -23,7 +23,8 @@
 
     .profile-top__options
       ul.profile-top__options__column
-        li = link("Send message", to: Routes.conversation_path(@conn, :new, recipient: @user.name))
+        = if can_create_convo?(@conn) do
+          li = link("Send message", to: Routes.conversation_path(@conn, :new, recipient: @user.name))
         li = link("Our conversations", to: Routes.conversation_path(@conn, :index, with: @user.id))
         li = link("Report this user", to: Routes.profile_report_path(@conn, :new, @user))
 

--- a/lib/philomena_web/views/conversation_view.ex
+++ b/lib/philomena_web/views/conversation_view.ex
@@ -28,4 +28,7 @@ defmodule PhilomenaWeb.ConversationView do
 
     Routes.conversation_path(conn, :show, conversation, page: page)
   end
+
+  def can_create_convo?(conn),
+    do: can?(conn, :new, Philomena.Conversations.Conversation)
 end

--- a/lib/philomena_web/views/profile_view.ex
+++ b/lib/philomena_web/views/profile_view.ex
@@ -70,6 +70,9 @@ defmodule PhilomenaWeb.ProfileView do
   def can_read_mod_notes?(conn),
     do: can?(conn, :index, Philomena.ModNotes.ModNote)
 
+  def can_create_convo?(conn),
+    do: can?(conn, :new, Philomena.Conversations.Conversation)
+
   def enabled_text(true), do: "Enabled"
   def enabled_text(_else), do: "Disabled"
 


### PR DESCRIPTION
Adds a (currently) mod-only permission to create new Conversations (private messages), and implements authorization-blocks in ConversationController, and link/button-hiding in profile and conversations pages.

Closes #44 