### PR TITLE
Remove duplicate SMTP_ env var entries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,10 +51,6 @@ services:
       - SMTP_DOMAIN
       - SMTP_USERNAME
       - SEED_ON_START=true
-      - SMTP_DOMAIN
-      - SMTP_PASSWORD
-      - SMTP_RELAY
-      - SMTP_USERNAME
     tty: true
     depends_on:
       - postgres


### PR DESCRIPTION
Removes duplicate SMTP_ environment variable entries, which docker-compose does not like at all.