### PR TITLE
Re-add name length and notable plugs to registration controller.

### DIFF
--- a/lib/philomena_web/controllers/registration_controller.ex
+++ b/lib/philomena_web/controllers/registration_controller.ex
@@ -5,6 +5,8 @@ defmodule PhilomenaWeb.RegistrationController do
   alias Philomena.Users.User
 
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
+  plug PhilomenaWeb.NameLengthLimiterPlug when action in [:create]
+  plug PhilomenaWeb.NotableNamePlug when action in [:create]
   plug PhilomenaWeb.CompromisedPasswordCheckPlug when action in [:create]
   plug :assign_email_and_password_changesets when action in [:edit]
 


### PR DESCRIPTION
Guess these got lost in the multiple big-PR attempts.