### PR TITLE
Multiple email-related fixes.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,12 @@ POSTGRES_PASSWORD=SampleSecret1234
 POSTGRES_HOST=postgres
 POSTGRES_DB=philomena_db
 POSTGRES_PORT=5432
+
+# Must be filled in for production
+#SMTP_RELAY=
+#SMTP_DOMAIN=
+#SMTP_USERNAME=philomena
+#SMTP_PASSWORD=SampleSecret1234
+
+MAILER_ADDRESS=booru@philomena.lc
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - SMTP_DOMAIN
       - SMTP_USERNAME
       - SEED_ON_START=true
+      - MAILER_ADDRESS
     tty: true
     depends_on:
       - postgres

--- a/lib/philomena/application.ex
+++ b/lib/philomena/application.ex
@@ -157,7 +157,7 @@ defmodule Philomena.Application do
     ]
     config = Vapor.load!([%Vapor.Provider.Env{bindings: bindings}])
     if !dev_mode do
-        Application.put_env(:philomena, PhilomenaWeb.Mailer, [
+        Application.put_env(:philomena, Philomena.Mailer, [
           adapter: Bamboo.SMTPAdapter,
           server: config.server,
           hostname: config.hostname,
@@ -169,7 +169,7 @@ defmodule Philomena.Application do
         ])
       else
         IO.puts("Starting local SMTP Adapter")
-        Application.put_env(:philomena, PhilomenaWeb.Mailer, [
+        Application.put_env(:philomena, Philomena.Mailer, [
           adapter: Bamboo.LocalAdapter
         ])
       end
@@ -179,6 +179,12 @@ defmodule Philomena.Application do
     ]
     config = Vapor.load!([%Vapor.Provider.Env{bindings: bindings}])
     Application.put_env(:bcrypt_elixir, :log_rounds, config.log_rounds)
+
+    bindings = [
+      { :mailer_address, "MAILER_ADDRESS", default: "test@philomena.lc", required: !dev_mode }
+    ]
+    config = Vapor.load!([%Vapor.Provider.Env{bindings: bindings}])
+    Application.put_env(:philomena, :mailer_address, config.mailer_address)
 
   end
 end

--- a/lib/philomena_web/plugs/dev_only_plug.ex
+++ b/lib/philomena_web/plugs/dev_only_plug.ex
@@ -1,0 +1,19 @@
+defmodule PhilomenaWeb.DevOnlyPlug do
+  alias Phoenix.Controller
+  alias Plug.Conn
+
+  def init([]), do: []
+
+  def call(conn), do: call(conn, nil)
+
+  def call(conn, _opts) do
+    case Application.get_env(:philomena, :app_env) do
+      "dev" ->
+        conn
+      _ ->
+        conn
+          |> Controller.redirect(to: "/")
+          |> Conn.halt()
+    end
+  end
+end

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -53,6 +53,16 @@ defmodule PhilomenaWeb.Router do
     plug PhilomenaWeb.FilterBannedUsersPlug
   end
 
+  pipeline :dev_only do
+    plug PhilomenaWeb.DevOnlyPlug
+  end
+
+  scope "/", Bamboo do
+    pipe_through [:dev_only]
+
+    forward "/sent_emails", SentEmailViewerPlug
+  end
+
   scope "/", PhilomenaWeb do
     pipe_through [:browser, :redirect_if_user_is_authenticated]
 


### PR DESCRIPTION
- Fixes app name in email-related config environment variable loading
- Adds `:mailer_address` env var loading from `MAILER_ADDRESS`, with a generic default
- Adds a simple `DevOnlyPlug` that checks `:app_env`, and redirects to / unless it's "dev"
  - Uses this plug to enable (for `APP_ENV=dev` only) the `Bamboo.SentEmailViewerPlug`, which shows emails sent via the `LocalAdapter` at /sent_emails.