### PR TITLE
Registration tweaks.

### DIFF
--- a/assets/css/common/_base.scss
+++ b/assets/css/common/_base.scss
@@ -86,7 +86,7 @@ a:hover {
   color: $link_hover_color;
 }
 
-p a {
+p a,.flash a {
   font-weight: bold;
 }
 

--- a/lib/philomena_web/controllers/registration/totp_controller.ex
+++ b/lib/philomena_web/controllers/registration/totp_controller.ex
@@ -47,7 +47,7 @@ defmodule PhilomenaWeb.Registration.TotpController do
 
       {:ok, user} ->
         conn
-        |> UserAuth.totp_auth_user(user, %{})
+        |> UserAuth.totp_auth_user(user, %{:allow_redirect => false})
         |> put_flash(:totp_backup_codes, backup_codes)
         |> redirect(to: Routes.registration_totp_path(conn, :edit))
     end

--- a/lib/philomena_web/plugs/notable_name_plug.ex
+++ b/lib/philomena_web/plugs/notable_name_plug.ex
@@ -29,10 +29,11 @@ defmodule PhilomenaWeb.NotableNamePlug do
   defp allow_mods(conn) do
     unless mod?(conn.assigns.current_user) do
       import Phoenix.HTML.Link, only: [link: 2]
+      import Phoenix.HTML.Tag
 
       conn
         |> Controller.fetch_flash()
-        |> Controller.put_flash(:error, ["That username is reserved for a notable fandom artist. Please choose another, and if you are the artist in question, ", link("contact the moderators", to: "/forums/meta"), " for verification."])
+        |> Controller.put_flash(:error, ["We've reserved that username in order to prevent impersonation.", tag(:br), "If you are the person in question, please see ", link("the forum", to: "/forums/meta/topics/name-verification"), " for more information."])
         |> Controller.redirect(external: conn.assigns.referrer)
         |> Conn.halt()
     else

--- a/lib/philomena_web/templates/registration/new.html.slime
+++ b/lib/philomena_web/templates/registration/new.html.slime
@@ -9,7 +9,7 @@ h1 Register
     ' Non-anonymous posts permanently show your username as of posting time,
     ' and may appear on search engines; choose wisely.
   .field
-    = text_input f, :name, class: "input", placeholder: "Username", required: true
+    = text_input f, :name, class: "input", placeholder: "Username", required: true, minlength: 2, maxlength: 80
     = error_tag f, :name
 
   .fieldlabel

--- a/lib/philomena_web/user_auth.ex
+++ b/lib/philomena_web/user_auth.ex
@@ -51,12 +51,20 @@ defmodule PhilomenaWeb.UserAuth do
   """
   def totp_auth_user(conn, user, params \\ %{}) do
     token = Users.generate_user_totp_token(user)
-    user_return_to = get_session(conn, :user_return_to)
 
     conn
     |> put_session(:totp_token, token)
     |> maybe_write_totp_auth_cookie(token, params)
-    |> redirect(to: user_return_to || signed_in_path(conn))
+    |> maybe_redirect(params)
+  end
+
+  defp maybe_redirect(conn, %{:allow_redirect => false}) do
+    conn
+  end
+  defp maybe_redirect(conn, _params) do
+    user_return_to = get_session(conn, :user_return_to)
+    conn
+      |> redirect(to: user_return_to || signed_in_path(conn))
   end
 
   defp maybe_write_totp_auth_cookie(conn, token, %{"remember_me" => "true"}) do


### PR DESCRIPTION
Improve and generify restricted name message, bold the link in it (and links in all flash messages), and set 80-char limit in the form field.