### PR TITLE
adjust image uploaded wait message as requested

### DIFF
--- a/lib/philomena_web/templates/image/_image_page.html.slime
+++ b/lib/philomena_web/templates/image/_image_page.html.slime
@@ -8,7 +8,8 @@
         p WEBM uploads may take longer to process, it should appear in up to an hour (depending on file size and video length).
       - else
         p The image should appear in a few minutes; report it otherwise.
-      p Implications might have added tags, so check them in the meanwhile.
+      p Implications might have added some tags, so check everything applies.
+      p If you are using a default filter, new images might be filtered out for some time to allow for correction of mistagging. Do not worry, your upload will be seen.
   = if !@image.processed and @image.thumbnails_generated do
     br
     #image-being-optimized.block.block--fixed.block--warning.layout--narrow


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

adjusted image uploaded wait message as requested, so that people know that images will be visible only a couple of minutes after uploading them.
