### PR TITLE
Hide Emails

### DIFF
--- a/lib/philomena_web/templates/admin/user/index.html.slime
+++ b/lib/philomena_web/templates/admin/user/index.html.slime
@@ -64,7 +64,6 @@ h1 Users
             = pretty_time user.created_at
 
           td
-
             => link "Edit", to: Routes.admin_user_path(@conn, :edit, user)
             ' &bull;
 

--- a/lib/philomena_web/templates/admin/user/index.html.slime
+++ b/lib/philomena_web/templates/admin/user/index.html.slime
@@ -21,7 +21,8 @@ h1 Users
     thead
       tr
         th Name
-        th Email
+        = if can_view_emails?(@conn) do
+          th Email
         th Activated
         th Role
         th Created
@@ -45,8 +46,9 @@ h1 Users
 
               - true ->
 
-          td
-            = user.email
+          = if can_view_emails?(@conn) do
+            td
+              = user.email
 
           td
             = if user.deleted_at do
@@ -62,6 +64,7 @@ h1 Users
             = pretty_time user.created_at
 
           td
+
             => link "Edit", to: Routes.admin_user_path(@conn, :edit, user)
             ' &bull;
 

--- a/lib/philomena_web/views/admin/user_view.ex
+++ b/lib/philomena_web/views/admin/user_view.ex
@@ -78,4 +78,7 @@ defmodule PhilomenaWeb.Admin.UserView do
       ["admin", "StaticPage"]
     ]
   end
+
+  def can_view_emails?(conn),
+    do: can?(conn, :index, :email_address)
 end


### PR DESCRIPTION
Hide emails from non-admins, except for mods with a special permission.

Relies on permission accidentally prematurely added to ability.ex in PR #55.