### PR TITLE
Disable anon reports, site-wide.

### DIFF
--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -336,7 +336,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(_user, :show, %Tag{}), do: true
 
   # Comment on images where that is allowed
-  def can?(%User{id: id}, :create_comment, %Image{hidden_from_users: false, commenting_allowed: true}),
+  def can?(%User{id: _id}, :create_comment, %Image{hidden_from_users: false, commenting_allowed: true}),
     do: true
 
   # Edit comments on images
@@ -372,7 +372,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(_user, :show, %Post{hidden_from_users: false}), do: true
 
   # Create and edit posts
-  def can?(%User{id: id}, :create_post, %Topic{locked_at: nil, hidden_from_users: false}), do: true
+  def can?(%User{id: _id}, :create_post, %Topic{locked_at: nil, hidden_from_users: false}), do: true
 
   def can?(%User{id: id}, action, %Post{hidden_from_users: false, user_id: id})
       when action in [:edit, :update],
@@ -389,6 +389,10 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
 
   def can?(_user, :show, %DnpEntry{aasm_state: "listed"}), do: true
   def can?(_user, :show_reason, %DnpEntry{aasm_state: "listed", hide_reason: false}), do: true
+
+  # Create reports
+  def can?(%User{id: _id}, action, Philomena.Reports.Report) when action in [:new, :create], do: true
+  def can?(%User{id: _id}, action, Philomena.DuplicateReports.DuplicateReport) when action in [:new, :create], do: true
 
   # Create and edit galleries
   def can?(_user, :show, %Gallery{}), do: true

--- a/lib/philomena_web/controllers/conversation/report_controller.ex
+++ b/lib/philomena_web/controllers/conversation/report_controller.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.Conversation.ReportController do
   alias Philomena.Reports
 
   plug PhilomenaWeb.FilterBannedUsersPlug
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
   plug PhilomenaWeb.CanaryMapPlug, new: :show, create: :show

--- a/lib/philomena_web/controllers/duplicate_report_controller.ex
+++ b/lib/philomena_web/controllers/duplicate_report_controller.ex
@@ -10,6 +10,7 @@ defmodule PhilomenaWeb.DuplicateReportController do
   @valid_states ~W(open rejected accepted claimed)
 
   plug PhilomenaWeb.FilterBannedUsersPlug when action in [:create]
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug when action in [:create]
 
   plug :load_resource,

--- a/lib/philomena_web/controllers/gallery/report_controller.ex
+++ b/lib/philomena_web/controllers/gallery/report_controller.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.Gallery.ReportController do
   alias Philomena.Reports
 
   plug PhilomenaWeb.FilterBannedUsersPlug
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
   plug PhilomenaWeb.CanaryMapPlug, new: :show, create: :show

--- a/lib/philomena_web/controllers/image/comment/report_controller.ex
+++ b/lib/philomena_web/controllers/image/comment/report_controller.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.Image.Comment.ReportController do
   alias Philomena.Reports
 
   plug PhilomenaWeb.FilterBannedUsersPlug
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
 

--- a/lib/philomena_web/controllers/image/report_controller.ex
+++ b/lib/philomena_web/controllers/image/report_controller.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.Image.ReportController do
   alias Philomena.Reports
 
   plug PhilomenaWeb.FilterBannedUsersPlug
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
   plug PhilomenaWeb.CanaryMapPlug, new: :show, create: :show

--- a/lib/philomena_web/controllers/profile/commission/report_controller.ex
+++ b/lib/philomena_web/controllers/profile/commission/report_controller.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.Profile.Commission.ReportController do
   alias Philomena.Reports
 
   plug PhilomenaWeb.FilterBannedUsersPlug
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
   plug PhilomenaWeb.CanaryMapPlug, new: :show, create: :show

--- a/lib/philomena_web/controllers/profile/report_controller.ex
+++ b/lib/philomena_web/controllers/profile/report_controller.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.Profile.ReportController do
   alias Philomena.Reports
 
   plug PhilomenaWeb.FilterBannedUsersPlug
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
   plug PhilomenaWeb.CanaryMapPlug, new: :show, create: :show

--- a/lib/philomena_web/controllers/topic/post/report_controller.ex
+++ b/lib/philomena_web/controllers/topic/post/report_controller.ex
@@ -8,9 +8,9 @@ defmodule PhilomenaWeb.Topic.Post.ReportController do
   alias Philomena.Reports
 
   plug PhilomenaWeb.FilterBannedUsersPlug
+  plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CaptchaPlug when action in [:create]
-
   plug PhilomenaWeb.CanaryMapPlug, new: :show, create: :show
 
   plug :load_and_authorize_resource,

--- a/lib/philomena_web/plugs/authorized_reporter_plug.ex
+++ b/lib/philomena_web/plugs/authorized_reporter_plug.ex
@@ -1,0 +1,33 @@
+defmodule PhilomenaWeb.AuthorizedReporterPlug do
+  @moduledoc """
+  Verifies that a user is allowed to submit Reports.
+  Effectively should end up checking the user is logged in.
+
+  ## Example
+
+      plug PhilomenaWeb.AuthorizedReporterPlug when action in [:new, :create]
+  """
+
+  alias Canada.Can
+
+  alias Phoenix.Controller
+  alias Philomena.Reports.Report
+  alias PhilomenaWeb.NotAuthorizedPlug
+
+  alias Plug.Conn
+
+  @spec init(any()) :: any()
+  def init(opts), do: opts
+
+  @spec call(Conn.t()) :: Conn.t()
+  def call(conn), do: call(conn, nil)
+
+  @spec call(Conn.t(), any()) :: Conn.t()
+  def call(conn, _opts) do
+    case Can.can?(conn.assigns.current_user, Controller.action_name(conn), Report) do
+      true -> conn
+      _false -> NotAuthorizedPlug.call(conn)
+    end
+  end
+end
+

--- a/lib/philomena_web/templates/comment/_comment_options.html.slime
+++ b/lib/philomena_web/templates/comment/_comment_options.html.slime
@@ -2,9 +2,10 @@ div
   ' Posted
   => pretty_time(@comment.created_at)
 
-  a.communication__interaction href=Routes.image_comment_report_path(@conn, :new, @comment.image, @comment)
-    i.fa.fa-flag>
-    ' Report
+  = if can_report?(@conn) do
+    a.communication__interaction href=Routes.image_comment_report_path(@conn, :new, @comment.image, @comment)
+      i.fa.fa-flag>
+      ' Report
 
   = if not is_nil(@comment.edited_at) and can?(@conn, :show, @comment) do
     br

--- a/lib/philomena_web/templates/gallery/show.html.slime
+++ b/lib/philomena_web/templates/gallery/show.html.slime
@@ -18,9 +18,10 @@ elixir:
       .flex__right
         = render PhilomenaWeb.ImageView, "_random_button.html", conn: @conn, params: scope
 
-        a href=Routes.gallery_report_path(@conn, :new, @gallery)
-          i.fa.fa-exclamation-triangle>
-          span.hide-mobile Report
+        = if can_report?(@conn) do
+          a href=Routes.gallery_report_path(@conn, :new, @gallery)
+            i.fa.fa-exclamation-triangle>
+            span.hide-mobile Report
 
         = if can?(@conn, :edit, @gallery) do
           a href=Routes.gallery_path(@conn, :edit, @gallery)

--- a/lib/philomena_web/templates/image/_options.html.slime
+++ b/lib/philomena_web/templates/image/_options.html.slime
@@ -2,9 +2,10 @@
 
 #image_options_area
   .block__header.block__header--js-tabbed
-    a href="#" data-click-tab="reporting" data-load-tab=Routes.image_reporting_path(@conn, :show, @image)
-      i.fa.fa-exclamation-triangle>
-      | Report
+    = if can_report?(@conn) do
+      a href="#" data-click-tab="reporting" data-load-tab=Routes.image_reporting_path(@conn, :show, @image)
+        i.fa.fa-exclamation-triangle>
+        | Report
     a href="#" data-click-tab="sharing"
       i.fa.fa-share>
       | Share

--- a/lib/philomena_web/templates/post/_post_options.html.slime
+++ b/lib/philomena_web/templates/post/_post_options.html.slime
@@ -2,9 +2,10 @@ div
   ' Posted
   => pretty_time(@post.created_at)
 
-  a.communication__interaction href=Routes.forum_topic_post_report_path(@conn, :new, @post.topic.forum, @post.topic, @post)
-    i.fa.fa-flag>
-    ' Report
+  = if can_report?(@conn) do
+    a.communication__interaction href=Routes.forum_topic_post_report_path(@conn, :new, @post.topic.forum, @post.topic, @post)
+      i.fa.fa-flag>
+      ' Report
 
   = if not is_nil(@post.edited_at) and can?(@conn, :show, @post) do
     br

--- a/lib/philomena_web/templates/profile/commission/_listing_sidebar.html.slime
+++ b/lib/philomena_web/templates/profile/commission/_listing_sidebar.html.slime
@@ -75,7 +75,8 @@
       br
       = link "Delete this listing", to: Routes.profile_commission_path(@conn, :delete, @user), data: [confirm: "Are you really, really sure about that?", method: :delete]
       br
-    = link "Report this listing", to: Routes.profile_commission_report_path(@conn, :new, @user)
+    = if can_report?(@conn) do
+      = link "Report this listing", to: Routes.profile_commission_report_path(@conn, :new, @user)
 
 / Share block
 .block

--- a/lib/philomena_web/templates/profile/show.html.slime
+++ b/lib/philomena_web/templates/profile/show.html.slime
@@ -26,7 +26,8 @@
         = if can_create_convo?(@conn) do
           li = link("Send message", to: Routes.conversation_path(@conn, :new, recipient: @user.name))
         li = link("Our conversations", to: Routes.conversation_path(@conn, :index, with: @user.id))
-        li = link("Report this user", to: Routes.profile_report_path(@conn, :new, @user))
+        = if can_report?(@conn) do
+          li = link("Report this user", to: Routes.profile_report_path(@conn, :new, @user))
 
       ul.profile-top__options__column
         li = link("Uploads", to: Routes.search_path(@conn, :index, q: "uploader_id:#{@user.id}"))

--- a/lib/philomena_web/views/comment_view.ex
+++ b/lib/philomena_web/views/comment_view.ex
@@ -1,3 +1,7 @@
 defmodule PhilomenaWeb.CommentView do
   use PhilomenaWeb, :view
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end

--- a/lib/philomena_web/views/conversation_view.ex
+++ b/lib/philomena_web/views/conversation_view.ex
@@ -29,6 +29,11 @@ defmodule PhilomenaWeb.ConversationView do
     Routes.conversation_path(conn, :show, conversation, page: page)
   end
 
+  @spec can_create_convo?(Plug.Conn.t()) :: boolean()
   def can_create_convo?(conn),
     do: can?(conn, :new, Philomena.Conversations.Conversation)
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end

--- a/lib/philomena_web/views/gallery_view.ex
+++ b/lib/philomena_web/views/gallery_view.ex
@@ -20,4 +20,8 @@ defmodule PhilomenaWeb.GalleryView do
 
   def show_subscription_link?(%{id: id}, %{id: id}), do: false
   def show_subscription_link?(_user1, _user2), do: true
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end

--- a/lib/philomena_web/views/image/comment_view.ex
+++ b/lib/philomena_web/views/image/comment_view.ex
@@ -4,4 +4,8 @@ defmodule PhilomenaWeb.Image.CommentView do
   def anonymous_by_default?(conn) do
     conn.assigns.current_user.anonymous_by_default
   end
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end

--- a/lib/philomena_web/views/image_view.ex
+++ b/lib/philomena_web/views/image_view.ex
@@ -263,4 +263,8 @@ defmodule PhilomenaWeb.ImageView do
 
     Philomena.Search.Evaluator.hits?(doc, query)
   end
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end

--- a/lib/philomena_web/views/post_view.ex
+++ b/lib/philomena_web/views/post_view.ex
@@ -33,4 +33,8 @@ defmodule PhilomenaWeb.PostView do
         object.user.name
     end
   end
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end

--- a/lib/philomena_web/views/profile/commission_view.ex
+++ b/lib/philomena_web/views/profile/commission_view.ex
@@ -7,4 +7,8 @@ defmodule PhilomenaWeb.Profile.CommissionView do
 
   def current?(%{id: id}, %{id: id}), do: true
   def current?(_user1, _user2), do: false
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end

--- a/lib/philomena_web/views/profile_view.ex
+++ b/lib/philomena_web/views/profile_view.ex
@@ -70,8 +70,13 @@ defmodule PhilomenaWeb.ProfileView do
   def can_read_mod_notes?(conn),
     do: can?(conn, :index, Philomena.ModNotes.ModNote)
 
+  @spec can_create_convo?(PLug.Conn.t()) :: boolean()
   def can_create_convo?(conn),
     do: can?(conn, :new, Philomena.Conversations.Conversation)
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 
   def enabled_text(true), do: "Enabled"
   def enabled_text(_else), do: "Disabled"

--- a/lib/philomena_web/views/topic/post_view.ex
+++ b/lib/philomena_web/views/topic/post_view.ex
@@ -4,4 +4,8 @@ defmodule PhilomenaWeb.Topic.PostView do
   def anonymous_by_default?(conn) do
     conn.assigns.current_user.anonymous_by_default
   end
+
+  @spec can_report?(Plug.Conn.t()) :: boolean()
+  def can_report?(conn),
+    do: can?(conn, :new, Philomena.Reports.Report)
 end


### PR DESCRIPTION
Adds new permission requiring log-in to report, added controller checks and button toggles for all (I hope) possible report origins.