### PR TITLE
Change confirmation redirect

### DIFF
--- a/lib/philomena_web/controllers/confirmation_controller.ex
+++ b/lib/philomena_web/controllers/confirmation_controller.ex
@@ -29,12 +29,15 @@ defmodule PhilomenaWeb.ConfirmationController do
 
   # Do not log in the user after confirmation to avoid a
   # leaked token giving the user access to the account.
+  #
+  # If confirmation was successful redirect the user to the
+  # login page.
   def show(conn, %{"id" => token}) do
     case Users.confirm_user(token) do
       {:ok, _} ->
         conn
         |> put_flash(:info, "Account confirmed successfully.")
-        |> redirect(to: "/")
+        |> redirect(to: "/sessions/new")
 
       :error ->
         conn


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
When a user successfully confirms their email this change will redirect them automatically to the login page where they may log in with their newly confirmed account.

This request was made in issue #58 and that issue should be closed if these changes are merged.
Closes #58