### PR TITLE
Add to API the ability to specify image ID (must agree with source_url)

### DIFF
--- a/lib/philomena/images/id_validator.ex
+++ b/lib/philomena/images/id_validator.ex
@@ -1,0 +1,55 @@
+defmodule Philomena.Images.IDValidator do
+  @id_set [%{:id_range => 1..4000000,
+             :site => "Derpibooru",
+             :url_bases => ["//derpibooru.org/~B",
+                            "//derpibooru.org/images/~B",
+                            "//trixiebooru.org/~B",
+                            "//trixiebooru.org/images/~B"]}]
+
+  @spec validate_id(integer(), String.t()) :: {atom(), String.t()}
+  def validate_id(id, url) do
+    case get_site(id) do
+      {site, url_bases} ->
+        case compare_urls(id, url_bases, url) do
+          :ok -> {:ok, site}
+          _ -> {:nok, site}
+        end
+      _ ->
+        {:nok, nil}
+    end
+  end
+
+  @spec compare_urls(integer(), [String.t()], String.t()) :: atom()
+  defp compare_urls(id, url_bases, test_url) do
+    test_url = URI.parse(test_url)
+    test_url = URI.to_string(%{test_url | scheme: nil, port: nil})
+
+    case Enum.any?(url_bases, fn(url_base) ->
+           url_base |> id_inject(id) == test_url
+         end) do
+      true ->
+        :ok
+      _ ->
+        :invalid
+    end
+  end
+
+  @spec id_inject(String.t(), integer()) :: String.t()
+  defp id_inject(url_base, id) do
+    url_base
+      |> :io_lib.format([id])
+      |> List.to_string()
+  end
+
+  @spec get_site(integer()) :: {String.t(), [String.t()]} | atom()
+  defp get_site(id) do
+    case Enum.find(@id_set, fn(sitemap) ->
+           Enum.member?(sitemap.id_range, id)
+         end) do
+      %{:site => site, :url_bases => url_bases} ->
+        {site, url_bases}
+      _ ->
+        :no_match
+    end
+  end
+end

--- a/lib/philomena/images/image.ex
+++ b/lib/philomena/images/image.ex
@@ -118,9 +118,19 @@ defmodule Philomena.Images.Image do
     |> cast(attrs, [:anonymous, :source_url, :description])
     |> change(first_seen_at: now)
     |> change(attribution)
+    |> maybe_cast_id(attrs)
     |> validate_length(:description, max: 50_000, count: :bytes)
     |> validate_format(:source_url, ~r/\Ahttps?:\/\//)
   end
+
+  defp maybe_cast_id(image, %{"id" => _id} = image_params) do
+    image
+      |> IO.inspect()
+      |> cast(image_params, [:id])
+      |> validate_number(:id, greater_than: 0)
+      |> IO.inspect()
+  end
+  defp maybe_cast_id(image, _attrs), do: image
 
   def image_changeset(image, attrs) do
     image

--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -131,6 +131,8 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(%User{role: "moderator", role_map: %{"SiteNotice" => "admin"}}, _action, %SiteNotice{}),
     do: true
 
+  def can?(%User{role: "moderator", role_map: %{"ViewEmails" => "admin"}}, :index, :email_address), do: true
+
   # Manage badges
   def can?(%User{role: "moderator", role_map: %{"Badge" => "admin"}}, _action, Badge), do: true
   def can?(%User{role: "moderator", role_map: %{"Badge" => "admin"}}, _action, %Badge{}), do: true
@@ -334,7 +336,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(_user, :show, %Tag{}), do: true
 
   # Comment on images where that is allowed
-  def can?(_user, :create_comment, %Image{hidden_from_users: false, commenting_allowed: true}),
+  def can?(%User{id: id}, :create_comment, %Image{hidden_from_users: false, commenting_allowed: true}),
     do: true
 
   # Edit comments on images
@@ -370,7 +372,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(_user, :show, %Post{hidden_from_users: false}), do: true
 
   # Create and edit posts
-  def can?(_user, :create_post, %Topic{locked_at: nil, hidden_from_users: false}), do: true
+  def can?(%User{id: id}, :create_post, %Topic{locked_at: nil, hidden_from_users: false}), do: true
 
   def can?(%User{id: id}, action, %Post{hidden_from_users: false, user_id: id})
       when action in [:edit, :update],

--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -10,6 +10,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   alias Philomena.DuplicateReports.DuplicateReport
   alias Philomena.DnpEntries.DnpEntry
   alias Philomena.Images.Image
+  alias Philomena.Images.IDValidator
   alias Philomena.Forums.Forum
   alias Philomena.Topics.Topic
   alias Philomena.ModNotes.ModNote
@@ -123,6 +124,9 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(%User{role: "moderator"}, :revert, TagChange), do: true
 
   # And some privileged moderators can...
+
+  # Upload w/ specific ID, without URL validation
+  def can?(%User{role: "moderator", role_map: %{"FreeIDUpload" => "admin"}}, :create, IDValidator), do: true
 
   # Manage site notices
   def can?(%User{role: "moderator", role_map: %{"SiteNotice" => "admin"}}, _action, SiteNotice),

--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -9,6 +9,7 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
 
   plug :set_scraper_cache
   plug PhilomenaWeb.ApiRequireAuthorizationPlug when action in [:create]
+  plug PhilomenaWeb.IDValidationPlug when action in [:create]
   plug PhilomenaWeb.UserAttributionPlug when action in [:create]
 
   plug PhilomenaWeb.ScraperPlug,

--- a/lib/philomena_web/plugs/id_validation_plug.ex
+++ b/lib/philomena_web/plugs/id_validation_plug.ex
@@ -1,0 +1,60 @@
+defmodule PhilomenaWeb.IDValidationPlug do
+  @moduledoc """
+  If an ID number was passed with an image upload, checks that the ID fits the
+  upload URL site.
+
+  ## Example
+
+      plug PhilomenaWeb.IDValidationPlug when action in [:create]
+  """
+  alias Philomena.Images.IDValidator
+  alias Plug.Conn
+
+  def init(opts), do: opts
+
+  @spec call(Conn.t(), map()) :: Conn.t()
+  def call(conn, _opts) do
+    image_params = conn.params["image"]
+
+    conn
+      |> maybe_validate_id(image_params)
+  end
+
+  @spec maybe_validate_id(Conn.t(), %{}) :: Conn.t()
+  # ID as string, try to convert to integer
+  defp maybe_validate_id(conn, %{"id" => id_str, "source_url" => url})
+  when is_binary(id_str) and is_binary(url) do
+    case Integer.parse(id_str) do
+      {id, ""} when is_integer(id) -> # reject all but pure ints
+        maybe_validate_id(conn, %{"id" => id, "source_url" => url})
+      _ ->
+        conn |> go_away(:bad_request)
+    end
+  end
+  # ID as integer, validate against source_url
+  defp maybe_validate_id(conn, %{"id" => id, "source_url" => url})
+  when is_integer(id) and is_binary(url) do
+    case IDValidator.validate_id(id, url) do
+      {:ok, _site} ->
+        conn
+      _ ->
+        conn
+          |> go_away(:expectation_failed)
+    end
+  end
+  # Other invalid ID values
+  defp maybe_validate_id(conn, %{"id" => _id}), do: conn |> go_away(:bad_request)
+  # No ID, handle as normal
+  defp maybe_validate_id(conn, _blorp), do: conn
+
+  @spec go_away(Conn.t(), integer() | atom()) :: Conn.t()
+  defp go_away(conn, reason) do
+    import Plug.Conn.Status
+    sc = code(reason)
+
+    conn
+      |> Conn.put_resp_content_type("text/plain")
+      |> Conn.send_resp(sc, reason_phrase(sc))
+      |> Conn.halt()
+  end
+end


### PR DESCRIPTION
- Add Ecto cast of ID to repo creation changeset if an ID was provided.
- Create `Philomena.Images.IDValidator` which provides `validate_id/2` to check if ID matches the provided `source_url`, along with structure containing map of ID number ranges to sites/source url bases (currently only Derpibooru).
- Create `PhilomenaWeb.IDValidationPlug` to handle checking for valid IDs (string or numeric IDs should work), and passing or rejecting uploads.
- Insert new plug into the API image controller.