### PR TITLE
Cherry-picked some fixes from philomena-dev (2020-08)

### DIFF
--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -124,6 +124,26 @@ function setupImageUpload() {
   else {
     disableFetch();
   }
+
+  // Catch unintentional navigation away from the page
+
+  function beforeUnload(event) {
+    // Chrome requires returnValue to be set
+    event.preventDefault();
+    event.returnValue = '';
+  }
+
+  function registerBeforeUnload() {
+    window.addEventListener('beforeunload', beforeUnload);
+  }
+
+  function unregisterBeforeUnload() {
+    window.removeEventListener('beforeunload', beforeUnload);
+  }
+
+  fileField.addEventListener('change', registerBeforeUnload);
+  fetchButton.addEventListener('click', registerBeforeUnload);
+  form.addEventListener('submit', unregisterBeforeUnload);
 }
 
 export { setupImageUpload };

--- a/lib/philomena/scrapers/tumblr.ex
+++ b/lib/philomena/scrapers/tumblr.ex
@@ -1,6 +1,6 @@
 defmodule Philomena.Scrapers.Tumblr do
   @url_regex ~r|\Ahttps?://(?:.*)/(?:image\|post)/(\d+)(?:\z\|[/?#])|
-  @inline_regex ~r|https?://(?:\d+\.)?media\.tumblr\.com\/[a-f\d]+\/tumblr(?:_inline)?_[a-z\d]+_\d+\.(?:png\|jpe?g\|gif)|i
+  @media_regex ~r|https?://(?:\d+\.)?media\.tumblr\.com/[a-f\d]+/[a-f\d]+-[a-f\d]+/s\d+x\d+/[a-f\d]+\.(?:png\|jpe?g\|gif)|i
   @size_regex ~r|_(\d+)(\..+)\z|
   @sizes [1280, 540, 500, 400, 250, 100, 75]
   @tumblr_ranges [
@@ -54,10 +54,10 @@ defmodule Philomena.Scrapers.Tumblr do
 
   defp process_post!(%{"type" => "text"} = post) do
     images =
-      @inline_regex
-      |> Regex.scan(post["text"])
-      |> Enum.map(fn url ->
-        %{url: upsize(url), camo_url: Camo.Image.image_url(url)}
+      @media_regex
+      |> Regex.scan(post["body"])
+      |> Enum.map(fn [url | _captures] ->
+        %{url: url, camo_url: Camo.Image.image_url(url)}
       end)
 
     add_meta(post, images)

--- a/lib/philomena_web/controllers/api/json/oembed_controller.ex
+++ b/lib/philomena_web/controllers/api/json/oembed_controller.ex
@@ -54,7 +54,7 @@ defmodule PhilomenaWeb.Api.Json.OembedController do
       version: "1.0",
       type: "photo",
       title: "##{image.id} - #{image.tag_list_cache} - YourBooruName",
-      author_url: image.source_url,
+      author_url: image.source_url || "",
       author_name: artist_tags(image.tags),
       provider_name: "YourBooruName",
       provider_url: PhilomenaWeb.Endpoint.url(),

--- a/lib/philomena_web/controllers/registration/totp_controller.ex
+++ b/lib/philomena_web/controllers/registration/totp_controller.ex
@@ -24,7 +24,7 @@ defmodule PhilomenaWeb.Registration.TotpController do
         qrcode = User.totp_qrcode(user)
 
         render(conn, "edit.html",
-          title: "Two-Factor Authentication",
+          title: "Two Factor Authentication",
           changeset: changeset,
           totp_secret: secret,
           totp_qrcode: qrcode

--- a/lib/philomena_web/templates/admin/user/index.html.slime
+++ b/lib/philomena_web/templates/admin/user/index.html.slime
@@ -51,11 +51,16 @@ h1 Users
               = user.email
 
           td
-            = if user.deleted_at do
-              strong> Deactivated
-              = pretty_time user.deleted_at
-            - else
-              ' Active
+            = cond do
+              - user.deleted_at ->
+                strong> Deactivated
+                = pretty_time user.deleted_at
+
+              - user.confirmed_at ->
+                ' Active
+
+              - true ->
+                strong> Unconfirmed
 
           td
             = String.capitalize(user.role)

--- a/lib/philomena_web/templates/profile/_admin_block.html.slime
+++ b/lib/philomena_web/templates/profile/_admin_block.html.slime
@@ -27,6 +27,7 @@
       ' (never)
 
   br
+  i.fas.fa-fw.fa-key>
   ' Two factor auth:
   strong = enabled_text(@user.otp_required_for_login)
 

--- a/lib/philomena_web/templates/registration/edit.html.slime
+++ b/lib/philomena_web/templates/registration/edit.html.slime
@@ -5,7 +5,7 @@ p
   a<> href="/settings/edit" Click here!
 
 p
-  ' Looking for two-factor authentication?
+  ' Looking for two factor authentication?
   = link "Click here!", to: Routes.registration_totp_path(@conn, :edit)
 
 p

--- a/lib/philomena_web/templates/registration/totp/edit.html.slime
+++ b/lib/philomena_web/templates/registration/totp/edit.html.slime
@@ -21,7 +21,7 @@ h1 Two Factor Authentication
       .block.block--fixed.block--success.layout--narrow
         h2 Two Factor Authentication Enabled
         p
-          ' You've successfully enabled two-factor authentication on your
+          ' You've successfully enabled two factor authentication on your
           ' account. From now on you'll be asked for the 6 digit code each
           ' time you log in.
         p


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

- add missing 2fa icon to admin thing and consistent spelling of "two factor"
- display unconfirmed users in admin users list
- fix discord oembed cards
- fix tumblr scrapes for text posts 
- require confirmation for navigation away from image upload form