### PR TITLE
fix elastic data mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     image: busybox
     volumes:
       - ./local-data/philomena:/system
-    command: /bin/chown -v 200:200 /system
+      - ./local-data/elastic:/elastic
+    command: /bin/chown -v 200:200 /system /elastic
     restart: "no"
 
   app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
   elasticsearch:
     image: elasticsearch:7.8.1
     volumes:
-      - ./local-data/elastic:/var/lib/elasticsearch
+      - ./local-data/elastic:/usr/share/elasticsearch/data
     environment:
       - discovery.type=single-node
     ulimits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,13 @@ services:
     volumes:
       - ./local-data/philomena:/system
       - ./local-data/elastic:/elastic
-    command: /bin/chown -v 200:200 /system /elastic
+    restart: "no"
+
+  init-elastic:
+    image: busybox
+    volumes:
+      - ./local-data/elastic:/elastic
+    command: /bin/chown -v 1000:0 /elastic
     restart: "no"
 
   app:
@@ -93,6 +99,8 @@ services:
       - ./local-data/elastic:/usr/share/elasticsearch/data
     environment:
       - discovery.type=single-node
+    depends_on:
+      - init-elastic
     ulimits:
       nofile:
           soft: 65536


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Elastic mounted the wrong folder into the FS: https://www.elastic.co/guide/en/elasticsearch/reference/7.8/docker.html

Before elastic is started again, ensure that the permissions for the ./local-data/elastic folder are 777 so elastic can spawn the proper folders inside.