### PR TITLE
Make Safari wrap URL links

### DIFF
--- a/assets/css/common/_base.scss
+++ b/assets/css/common/_base.scss
@@ -77,6 +77,11 @@ pre {
   font-family: $font_family_monospace;
 }
 
+a { /* Workaround for Safari URL wrapping bug */
+    word-break: break-word;
+    -webkit-hyphens: none;
+}
+
 a, a:active, a:visited {
   color: $link_color;
   text-decoration: none;


### PR DESCRIPTION
Default URL wrapping (at least as philomena has things set up) is:
* Safari: no wrapping except on hyphens/dashes in the URL, overflow off into oblivion screwing with page width (esp. on mobile devices).
* Firefox: wrap at slashes (and possibly other special characters?)
* Chrome: wrap anywhere

This change makes Safari behave like Chrome, without affecting Firefox.

Issue was reported regarding source URLs on image pages, but made it general to all a elements in case this could be messing with mobile layout elsewhere (and I don't think it will break anything).