### PR TITLE
Add G5 quicktags

### DIFF
--- a/config/quick_tag_table.json
+++ b/config/quick_tag_table.json
@@ -11,6 +11,7 @@
     "fs",
     "pp",
     "misc",
+    "g5",
     "Season 9",
     "8",
     "7",
@@ -33,6 +34,7 @@
     "fs": "shipping",
     "pp": "shipping",
     "misc": "shipping",
+    "g5": "default",
     "Season 9": "season",
     "8": "season",
     "7": "season",
@@ -269,6 +271,21 @@
       "applejack",
       "fluttershy",
       "pinkie pie"
+    ]
+  },
+  "g5": {
+    "Characters": [
+      "character:sunny starscout",
+      "character:izzy moonbow",
+      "character:zipp storm",
+      "character:pipp petals",
+      "character:hitch trailblazer",
+      "character:sprout",
+      "character:queen haven",
+      "character:argyle starshine",
+      "character:alphabittle",
+      "character:phyllis cloverleaf",
+      "character:sugar moonglow"
     ]
   },
   "Season 9": [


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Adds the G5 Movie Tags to the quicktag box
