### PR TITLE
Fix Dockerfile.app

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -3,8 +3,6 @@ FROM elixir:1.10.3
 RUN apt-get update \
     && apt-get -qq -y install apt-transport-https \
     && echo "deb https://deb.nodesource.com/node_12.x stretch main" >> /etc/apt/sources.list \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list \
-    && wget -qO - "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | apt-key add - \
     && wget -qO - "https://deb.nodesource.com/gpgkey/nodesource.gpg.key" | apt-key add - \
     && apt-get update \
     && apt-get -qq -y install inotify-tools netcat postgresql-client build-essential git ffmpeg libavformat-dev libavcodec-dev libswscale-dev nodejs libmagic-dev libpng-dev gifsicle optipng libjpeg-progs librsvg2-bin


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of this imageboard software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

I receive an error when trying to build the docker image:
![afbeelding](https://user-images.githubusercontent.com/19996084/139592113-b965a0ad-5d2c-47bd-a34c-92ce0d6b9f6c.png)

After some debugging. I found that the "postgresql-client" package apt-key could not be used.
So, I removed it and let it install via default Debian reference.
Now everything looks like it is working again.